### PR TITLE
ZaRR-119 Enable ckanext-versions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -68,6 +68,7 @@ ckanext-sentry = {ref = "0.1.0", git = "https://github.com/fjelltopp/ckanext-sen
 ckanext-authz-service = {editable = true, ref = "bd4c80f55a714c1117a0e130d07463e383c494c7", git = "https://github.com/datopian/ckanext-authz-service"}
 ckanext-blob-storage = {editable = true, ref = "5b2f59217e8f88a3f2cdb9dc50bf4099d9abe0de", git = "https://github.com/fjelltopp/ckanext-blob-storage"}
 ckanext-scheming = {editable = true, ref = "8d62a28370c4f231dbf2f9688ede93a0356410e3", git = "https://github.com/ckan/ckanext-scheming.git"}
+ckanext-versions = {editable = true, ref = "3a6094acd730f3495b0f8b99b14a2340042a721b", git = "https://github.com/datopian/ckanext-versions"}
 # Markupsafe and isdangerous downgraded because of dependencies issue
 markupsafe = "==2.0.1"
 itsdangerous = "==2.0.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ecc0aff488965880af587dfb8aeed20fdbafcf751551b6d496e01a7036782726"
+            "sha256": "d3598c558bb6779e4744d5f7cc9c8098e61c0eb0a74820498479c0cef3e095b1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -344,6 +344,11 @@
             "git": "https://github.com/fjelltopp/ckanext-sentry",
             "ref": "6389c73806098fc71239cc292ce85ac5b2d0965a"
         },
+        "ckanext-versions": {
+            "editable": true,
+            "git": "https://github.com/datopian/ckanext-versions",
+            "ref": "3a6094acd730f3495b0f8b99b14a2340042a721b"
+        },
         "ckanext-zarr": {
             "editable": true,
             "path": "./ckanext-zarr"
@@ -623,7 +628,7 @@
                 "sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f",
                 "sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812"
             ],
-            "markers": "python_version < '3.9'",
+            "markers": "python_version < '3.10'",
             "version": "==8.0.0"
         },
         "importlib-resources": {
@@ -2690,7 +2695,7 @@
                 "sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f",
                 "sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812"
             ],
-            "markers": "python_version < '3.9'",
+            "markers": "python_version < '3.10'",
             "version": "==8.0.0"
         },
         "importlib-resources": {


### PR DESCRIPTION
## Description
@ChasNelson1990 , I have enabled the base ckanext-versions, because:

- less error in the UI, probably the template changes are in ckanext-unaids 
- I do not know specifically what was the original ckanext-versions forked for
- the repository last commit is a few months recent than the one we forked

Original
![image](https://github.com/user-attachments/assets/578f3b9a-fc68-49f7-94d0-a4630ecc2a36)

Fork
![image](https://github.com/user-attachments/assets/6f76539e-217b-406f-925b-98caadd877ca)

I do not enable auto-merge in case we decide the forked version.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
