### PR TITLE
fix: update dsl.groovy to handle submodules

### DIFF
--- a/jenkins/dsl.groovy
+++ b/jenkins/dsl.groovy
@@ -88,6 +88,11 @@ pipelineJob("CKAN-deploy") {
             credentials('jenkins_github_ssh')
             name('origin')
           }
+          extensions {
+            submoduleOptions {
+              parentCredentials(true)
+            }
+          }
           scriptPath('jenkinsfiles/zarr_deploy.groovy')
           branch("remotes/origin/master")
         }


### PR DESCRIPTION
## Description

This fix is required to ensure that Jenkins can pull submodules correctly.

## Testing

Tested by deploying staging and production via Jenkins successfully.

## Documentation

Also updated fjelltopp/ckan_project_template

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
