### PR TITLE
feat: improve demo data to include TRG insitutes and group icons

### DIFF
--- a/util/demo_data_loader/ckan_loader.py
+++ b/util/demo_data_loader/ckan_loader.py
@@ -153,7 +153,7 @@ def load_resources(ckan, documents):
             _upload_resource(ckan, file_path, resource_dict)
 
 
-def load_groups(ckan, documents):
+def load_groups(ckan):
     """
     Helper method to load groups from the GROUPS_FILE config file
     :param ckan: ckanapi instance
@@ -191,8 +191,8 @@ def load_data(ckan_url, ckan_api_key):
     documents = _load_documents()
 
     load_users(ckan)
-    orgs = load_organizations(ckan)
-    load_groups(ckan, documents)
+    load_organizations(ckan)
+    load_groups(ckan)
     load_datasets(ckan, documents)
     load_resources(ckan, documents)
 

--- a/util/demo_data_loader/inputs/demo_data/groups.json
+++ b/util/demo_data_loader/inputs/demo_data/groups.json
@@ -3,150 +3,156 @@
       {
         "users": [
           {
-            "name": "test_admin",
+            "name": "fjelltopp_admin",
             "capacity": "admin"
-          },
-          {
-            "name": "test_editor",
-            "capacity": "editor"
-          },
-          {
-            "name": "test_member",
-            "capacity": "member"
           }
         ],
-        "display_name": "Publication",
-        "description": "Department publications and research studies",
-        "image_url": "https://dms.hiv.health.gov.mw/uploads/group/2022-03-17-123757.433896243660articlesquareicon.png",
-        "name": "publication",
+        "display_name": "Audio",
+        "description": "A resource primarily intended to be heard. Examples include a music playback file format, an audio compact disc, and recorded speech or sounds.",
+        "image_url": "https://raw.githubusercontent.com/google/material-design-icons/refs/heads/master/png/av/audio_file/materialiconsoutlined/48dp/2x/outline_audio_file_black_48dp.png",
+        "name": "sound",
         "state": "active",
-        "title": "Publication"
-      }, {
+        "title": "Audio"
+      },
+      {
         "users": [
           {
-            "name": "test_admin",
+            "name": "fjelltopp_admin",
             "capacity": "admin"
-          },
-          {
-            "name": "test_editor",
-            "capacity": "editor"
-          },
-          {
-            "name": "test_member",
-            "capacity": "member"
           }
         ],
-        "display_name": "Guideline",
-        "description": "Guidelines for health service staff",
-        "image_url": "https://dms.hiv.health.gov.mw/uploads/group/2022-03-17-123643.7336343533402businessmanagementplanprojectreporticon.png",
-        "name": "guideline",
+        "display_name": "Collection",
+        "description": "An aggregation of resources. A collection is described as a group; its parts may also be separately described.",
+        "image_url": "https://raw.githubusercontent.com/google/material-design-icons/refs/heads/master/png/av/library_books/materialiconsoutlined/48dp/2x/outline_library_books_black_48dp.png",
+        "name": "collection",
         "state": "active",
-        "title": "Guideline"
-      }, {
+        "title": "Collection"
+      },
+      {
         "users": [
           {
-            "name": "test_admin",
+            "name": "fjelltopp_admin",
             "capacity": "admin"
-          },
-          {
-            "name": "test_editor",
-            "capacity": "editor"
-          },
-          {
-            "name": "test_member",
-            "capacity": "member"
           }
         ],
-        "display_name": "Circulars",
-        "description": "Department internal circulars and reports",
-        "image_url": "https://dms.hiv.health.gov.mw/uploads/group/2022-03-17-123603.1298852205240clusterdatagrouporganizeicon.png",
-        "name": "circular",
+        "display_name": "Dataset",
+        "description": "Data encoded in a defined structure. Examples include lists, tables, and databases. A dataset may be useful for direct machine processing.",
+        "image_url": "https://raw.githubusercontent.com/google/material-design-icons/refs/heads/master/png/action/table_view/materialiconsoutlined/48dp/2x/outline_table_view_black_48dp.png",
+        "name": "dataset",
         "state": "active",
-        "title": "Circulars"
-      }, {
+        "title": "Dataset"
+      },
+      {
         "users": [
           {
-            "name": "test_admin",
+            "name": "fjelltopp_admin",
             "capacity": "admin"
-          },
-          {
-            "name": "test_editor",
-            "capacity": "editor"
-          },
-          {
-            "name": "test_member",
-            "capacity": "member"
           }
         ],
-        "display_name": "Data",
-        "description": "Data group for demo purposes",
-        "image_url": "https://dms.hiv.health.gov.mw//uploads/group/2022-07-24-152420.906558circular.png",
-        "name": "data",
+        "display_name": "Document",
+        "description": "A resource consisting primarily of words for reading. Examples include books, letters, dissertations, poems, newspapers, articles, archives of mailing lists. Note that facsimiles or images of texts are still of the genre Text.",
+        "image_url": "https://raw.githubusercontent.com/google/material-design-icons/refs/heads/master/png/action/description/materialiconsoutlined/48dp/2x/outline_description_black_48dp.png",
+        "name": "text",
         "state": "active",
-        "title": "Data"
-      }, {
+        "title": "Document"
+      },
+      {
         "users": [
           {
-            "name": "test_admin",
+            "name": "fjelltopp_admin",
             "capacity": "admin"
-          },
-          {
-            "name": "test_editor",
-            "capacity": "editor"
-          },
-          {
-            "name": "test_member",
-            "capacity": "member"
           }
         ],
-        "display_name": "Minutes",
-        "description": "Minutes group for demo purposes",
-        "image_url": "https://dms.hiv.health.gov.mw/uploads/group/2022-03-17-123701.0261814308050communicationconnectionmeetingofficeicon.png",
-        "name": "minutes",
+        "display_name": "Event",
+        "description": "A non-persistent, time-based occurrence. Metadata for an event provides descriptive information that is the basis for discovery of the purpose, location, duration, and responsible agents associated with an event. Examples include an exhibition, webcast, conference, workshop, open day, performance, battle, trial, wedding, tea party, conflagration.",
+        "image_url": "https://raw.githubusercontent.com/google/material-design-icons/refs/heads/master/png/action/event/materialiconsoutlined/48dp/2x/outline_event_black_48dp.png",
+        "name": "event",
         "state": "active",
-        "title": "Minutes"
-      }, {
+        "title": "Event"
+      },
+      {
         "users": [
           {
-            "name": "test_admin",
+            "name": "fjelltopp_admin",
             "capacity": "admin"
-          },
-          {
-            "name": "test_editor",
-            "capacity": "editor"
-          },
-          {
-            "name": "test_member",
-            "capacity": "member"
           }
         ],
-        "display_name": "Monitoring Tool",
-        "description": "Monitoring tool group for demo purposes",
-        "image_url": "https://dms.hiv.health.gov.mw/uploads/group/2022-03-17-123717.467925211661eyeicon.png",
-        "name": "monitoring",
+        "display_name": "Image",
+        "description": "A visual representation other than text. Examples include images and photographs of physical objects, paintings, prints, drawings, other images and graphics, animations and moving pictures, film, diagrams, maps, musical notation. Note that Image may include both electronic and physical representations.",
+        "image_url": "https://raw.githubusercontent.com/google/material-design-icons/refs/heads/master/png/image/photo_camera/materialiconsoutlined/48dp/2x/outline_photo_camera_black_48dp.png",
+        "name": "still_image",
         "state": "active",
-        "title": "Monitoring Tool"
-      }, {
+        "title": "Image"
+      },
+      {
         "users": [
           {
-            "name": "test_admin",
+            "name": "fjelltopp_admin",
             "capacity": "admin"
-          },
-          {
-            "name": "test_editor",
-            "capacity": "editor"
-          },
-          {
-            "name": "test_member",
-            "capacity": "member"
           }
         ],
-        "display_name": "Plan",
-        "description": "Plan group for demo purposes",
-        "image_url": "https://dms.hiv.health.gov.mw/uploads/group/2022-03-17-123743.3695114308313economicsmarketplanstrategicstrategyicon.png",
-        "name": "plan",
+        "display_name": "Interactive Resource",
+        "description": "A resource requiring interaction from the user to be understood, executed, or experienced. Examples include forms on Web pages, applets, multimedia learning objects, chat services, or virtual reality environments.",
+        "image_url": "https://raw.githubusercontent.com/google/material-design-icons/refs/heads/master/png/action/touch_app/materialiconsoutlined/48dp/2x/outline_touch_app_black_48dp.png",
+        "name": "interactive_resource",
         "state": "active",
-        "title": "Plan"
+        "title": "Interactive Resource"
+      },
+      {
+        "users": [
+          {
+            "name": "fjelltopp_admin",
+            "capacity": "admin"
+          }
+        ],
+        "display_name": "Physical Object",
+        "description": "An inanimate, three-dimensional object or substance. Note that digital representations of, or surrogates for, these objects should use Image, Text or one of the other types.",
+        "image_url": "https://raw.githubusercontent.com/google/material-design-icons/refs/heads/master/png/action/view_in_ar/materialiconsoutlined/48dp/2x/outline_view_in_ar_black_48dp.png",
+        "name": "physical_object",
+        "state": "active",
+        "title": "Physical Object"
+      },
+      {
+        "users": [
+          {
+            "name": "fjelltopp_admin",
+            "capacity": "admin"
+          }
+        ],
+        "display_name": "Service",
+        "description": "A system that provides one or more functions. Examples include a photocopying service, a banking service, an authentication service, interlibrary loans, a Z39.50 or Web server.",
+        "image_url": "https://raw.githubusercontent.com/google/material-design-icons/refs/heads/master/png/notification/support_agent/materialiconsoutlined/48dp/2x/outline_support_agent_black_48dp.png",
+        "name": "service",
+        "state": "active",
+        "title": "Service"
+      },
+      {
+        "users": [
+          {
+            "name": "fjelltopp_admin",
+            "capacity": "admin"
+          }
+        ],
+        "display_name": "Software",
+        "description": "A computer program in source or compiled form. Examples include a C source file, MS-Windows .exe executable, or Perl script.",
+        "image_url": "https://raw.githubusercontent.com/google/material-design-icons/refs/heads/master/png/action/terminal/materialiconsoutlined/48dp/2x/outline_terminal_black_48dp.png",
+        "name": "software",
+        "state": "active",
+        "title": "Software"
+      },
+      {
+        "users": [
+          {
+            "name": "fjelltopp_admin",
+            "capacity": "admin"
+          }
+        ],
+        "display_name": "Video",
+        "description": "A series of visual representations imparting an impression of motion when shown in succession. Examples include animations, movies, television programs, videos, zoetropes, or visual output from a simulation.",
+        "image_url": "https://raw.githubusercontent.com/google/material-design-icons/refs/heads/master/png/av/videocam/materialiconsoutlined/48dp/2x/outline_videocam_black_48dp.png",
+        "name": "moving_image",
+        "state": "active",
+        "title": "Video"
       }
     ]
   }

--- a/util/demo_data_loader/inputs/demo_data/organizations.json
+++ b/util/demo_data_loader/inputs/demo_data/organizations.json
@@ -1,26 +1,186 @@
 {
-    "organizations": [
-      {
-        "users": [
-          {
-            "name": "fjelltopp_admin",
-            "capacity": "admin"
-          },
-          {
-            "name": "fjelltopp_editor",
-            "capacity": "editor"
-          },
-          {
-            "name": "fjelltopp_member",
-            "capacity": "member"
-          }
-        ],
-        "display_name": "Fjelltopp",
-        "description": "Fjelltopp demo organization",
-        "image_url": "https://www.fjelltopp.org/templates/fjelltopp/images/navbar.png",
-        "name": "fjelltopp",
-        "state": "active",
-        "title": "Fjelltopp"
-      }
-    ]
-  }
+  "organizations": [
+    {
+      "users": [
+        {
+          "name": "fjelltopp_admin",
+          "capacity": "admin"
+        }
+      ],
+      "display_name": "Fjelltopp",
+      "description": "Fjelltopp are the service provider delivering the Zambia Research and Evaluation Repository",
+      "image_url": "https://www.fjelltopp.org/wp-content/themes/fjelltopp/assets/images/logo.png",
+      "name": "fjelltopp",
+      "state": "active",
+      "title": "Fjelltopp"
+    },
+    {
+      "users": [
+        {
+          "name": "mofnp_admin",
+          "capacity": "admin"
+        }
+      ],
+      "display_name": "Ministry of Finance and National Planning",
+      "description": "Government of the Republic of Zambia Ministry of Finance and National Planning",
+      "image_url": "https://www.mofnp.gov.zm/wp-content/uploads/2022/05/logo.fw_-4-768x105.png",
+      "name": "mofnp",
+      "state": "active",
+      "title": "Ministry of Finance and National Planning"
+    },
+    {
+      "users": [
+        {
+          "name": "medu_admin",
+          "capacity": "admin"
+        }
+      ],
+      "display_name": "Ministry of Education",
+      "description": "Government of the Republic of Zambia Ministry of Education",
+      "image_url": "https://www.edu.gov.zm/wp-content/uploads/2024/06/edu-loogo2-e1718996036101.png",
+      "name": "medu",
+      "state": "active",
+      "title": "Ministry of Education"
+    },
+    {
+      "users": [
+        {
+          "name": "moh_admin",
+          "capacity": "admin"
+        }
+      ],
+      "display_name": "Ministry of Health",
+      "description": "Government of the Republic of Zambia Ministry of Health",
+      "image_url": "https://www.moh.gov.zm/wp-content/uploads/2021/10/log_moh.gif",
+      "name": "moh",
+      "state": "active",
+      "title": "Ministry of Health"
+    },
+    {
+      "users": [
+        {
+          "name": "nhra_admin",
+          "capacity": "admin"
+        }
+      ],
+      "display_name": "National Health Research Authority",
+      "description": "Zambia National Health Research Authority (NHRA)",
+      "image_url": "https://images.squarespace-cdn.com/content/v1/5a76debf2aeba5bf135a4ea0/b94ab9fb-aa44-41c0-8a42-219c554cde00/updated+logo%281%29.jpg",
+      "name": "nhra",
+      "state": "active",
+      "title": "National Health Research Authority (NHRA)"
+    },
+    {
+      "users": [
+        {
+          "name": "nisir_admin",
+          "capacity": "admin"
+        }
+      ],
+      "display_name": "National Institute for Scientific and Industrial Research",
+      "description": "Zambia National Institute for Scientific and Industrial Research (NISIR)",
+      "image_url": "https://nisir.org.zm/wp-content/uploads/2020/07/cropped-WhatsApp_Image_2023-05-17_at_14.42.05-removebg-preview-1.png",
+      "name": "nisir",
+      "state": "active",
+      "title": "National Institute for Scientific and Industrial Research (NISIR)"
+    },
+    {
+      "users": [
+        {
+          "name": "smart_zambia_admin",
+          "capacity": "admin"
+        }
+      ],
+      "display_name": "Zambia Smart Zambia Institute",
+      "description": "Government of the Republic of Zambia Smart Zambia Institute",
+      "image_url": "https://www.szi.gov.zm/wp-content/uploads/2022/01/logoszi_2.png",
+      "name": "smart_zambia",
+      "state": "active",
+      "title": "Zambia Smart Zambia Institute"
+    },
+    {
+      "users": [
+        {
+          "name": "saipar_admin",
+          "capacity": "admin"
+        }
+      ],
+      "display_name": "Southern African Institute for Policy and Research",
+      "description": "Southern African Institute for Policy and Research",
+      "image_url": "http://saipar.org/wp-content/uploads/2013/09/SAIPAR-Logo.jpg",
+      "name": "saipar",
+      "state": "active",
+      "title": "Southern African Institute for Policy and Research"
+    },
+    {
+      "users": [
+        {
+          "name": "unicef_admin",
+          "capacity": "admin"
+        }
+      ],
+      "display_name": "UNICEF Zambia Office",
+      "description": "UNICEF Zambia Country Office",
+      "image_url": "hhttps://www.unicef.org/southafrica/themes/custom/unicef_base/UNICEF_ForEveryChild_White_Vertical_RGB_ENG.jpg",
+      "name": "unicef",
+      "state": "active",
+      "title": "UNICEF Zambia Office"
+    },
+    {
+      "users": [
+        {
+          "name": "unza_admin",
+          "capacity": "admin"
+        }
+      ],
+      "display_name": "University of Zambia Library",
+      "description": "University of Zambia (UNZA) Library",
+      "image_url": "https://www.unza.zm/themes/unza/logo.svg",
+      "name": "unza",
+      "state": "active",
+      "title": "University of Zambia (UNZA) Library"
+    },
+    {
+      "users": [
+        {
+          "name": "zipar_admin",
+          "capacity": "admin"
+        }
+      ],
+      "display_name": "Institute of Policy Analysis and Research",
+      "description": "Zambia Institute of Policy Analysis and Research (ZIPAR)",
+      "image_url": "https://www.zipar.org.zm/wp-content/uploads/2023/10/logo.png",
+      "name": "zipar",
+      "state": "active",
+      "title": "Institute of Policy Analysis and Research (ZIPAR)"
+    },
+    {
+      "users": [
+        {
+          "name": "zamren_admin",
+          "capacity": "admin"
+        }
+      ],
+      "display_name": "Zambia Research and Education Network",
+      "description": "Zambia Research and Education Network (ZAMREN)",
+      "image_url": "https://zamren.zm/wp-content/uploads/2020/05/cropped-ZAMREN_LOGO-clear-B-3-2.png",
+      "name": "zamren",
+      "state": "active",
+      "title": "Zambia Research and Education Network (ZAMREN)"
+    },
+    {
+      "users": [
+        {
+          "name": "zamstats_admin",
+          "capacity": "admin"
+        }
+      ],
+      "display_name": "Zambia Statistics Agency",
+      "description": "Government of the Republic of Zambia Statistics Agency (ZamStats)",
+      "image_url": "https://www.zamstats.gov.zm/wp-content/uploads/2023/11/logo.jpg",
+      "name": "zamstats",
+      "state": "active",
+      "title": "Zambia Statistics Agency (ZamStats)"
+    }
+  ]
+}

--- a/util/demo_data_loader/inputs/demo_data/users.json
+++ b/util/demo_data_loader/inputs/demo_data/users.json
@@ -1,64 +1,135 @@
 {
     "users": [
       {
-        "email": "fjelltopp_admin@fjelltopp.org",
+        "email": "info+zarr_mofnp@fjelltopp.org",
         "about": null,
-        "display_name": "Fjelltopp Admin",
+        "display_name": "MOFNP Admin",
+        "name": "mofnp_admin",
+        "password": "fjelltopp",
+        "activity_streams_email_notifications": false,
+        "state": "active",
+        "fullname": "Zambia Ministry of Finance and National Planning"
+      },
+      {
+        "email": "info+zarr_moh@fjelltopp.org",
+        "about": null,
+        "display_name": "MOH Admin",
+        "name": "moh_admin",
+        "password": "fjelltopp",
+        "activity_streams_email_notifications": false,
+        "state": "active",
+        "fullname": "Zambia Ministry of Health"
+      },
+      {
+        "email": "info+zarr_medu@fjelltopp.org",
+        "about": null,
+        "display_name": "MEdu Admin",
+        "name": "medu_admin",
+        "password": "fjelltopp",
+        "activity_streams_email_notifications": false,
+        "state": "active",
+        "fullname": "Zambia Ministry of Education"
+      },
+      {
+        "email": "info+zarr_zamstats@fjelltopp.org",
+        "about": null,
+        "display_name": "ZamStats Admin",
+        "name": "zamstats_admin",
+        "password": "fjelltopp",
+        "activity_streams_email_notifications": false,
+        "state": "active",
+        "fullname": "Zambia Statistics Agency Admin"
+      },
+      {
+        "email": "info+zarr_smartzambia@fjelltopp.org",
+        "about": null,
+        "display_name": "Smart Zambia Admin",
+        "name": "smart_zambia_admin",
+        "password": "fjelltopp",
+        "activity_streams_email_notifications": false,
+        "state": "active",
+        "fullname": "Smart Zambia Admin"
+      },
+      {
+        "email": "info+zarr_zipar@fjelltopp.org",
+        "about": null,
+        "display_name": "ZIPAR Admin",
+        "name": "zipar_admin",
+        "password": "fjelltopp",
+        "activity_streams_email_notifications": false,
+        "state": "active",
+        "fullname": "Zambia Institute of Policy Analysis and Research Admin"
+      },
+      {
+        "email": "info+zarr_nisir@fjelltopp.org",
+        "about": null,
+        "display_name": "NISIR Admin",
+        "name": "nisir_admin",
+        "password": "fjelltopp",
+        "activity_streams_email_notifications": false,
+        "state": "active",
+        "fullname": "Zambia National Institute for Scientific and Industrial Research Admin"
+      },
+      {
+        "email": "info+zarr_unzalibrary@fjelltopp.org",
+        "about": null,
+        "display_name": "UNZA Library Admin",
+        "name": "unza_library_admin",
+        "password": "fjelltopp",
+        "activity_streams_email_notifications": false,
+        "state": "active",
+        "fullname": "Univcersity of Zambia Library Admin"
+      },
+      {
+        "email": "info+zarr_zamren@fjelltopp.org",
+        "about": null,
+        "display_name": "ZAMREN Admin",
+        "name": "zamren_admin",
+        "password": "fjelltopp",
+        "activity_streams_email_notifications": false,
+        "state": "active",
+        "fullname": "Zambia Research and Education Network Admin"
+      },
+      {
+        "email": "info+zarr_nhra@fjelltopp.org",
+        "about": null,
+        "display_name": "NHHRA Admin",
+        "name": "nhra_admin",
+        "password": "fjelltopp",
+        "activity_streams_email_notifications": false,
+        "state": "active",
+        "fullname": "Zambia National Health Research Authority Admin"
+      },
+      {
+        "email": "info+zarr_saipar@fjelltopp.org",
+        "about": null,
+        "display_name": "SAIPAR Admin",
+        "name": "saipar_admin",
+        "password": "fjelltopp",
+        "activity_streams_email_notifications": false,
+        "state": "active",
+        "fullname": "Southern African Institute for Policy and Research Admin"
+      },
+      {
+        "email": "info+zarr_unicef@fjelltopp.org",
+        "about": null,
+        "display_name": "UNICEF Zambia Admin",
+        "name": "unicef_admin",
+        "password": "fjelltopp",
+        "activity_streams_email_notifications": false,
+        "state": "active",
+        "fullname": "UNICEF Zambia Admin"
+      },
+      {
+        "email": "chas@fjelltopp.org",
+        "about": null,
+        "display_name": "Dr Chas Nelson (Fjelltopp)",
         "name": "fjelltopp_admin",
         "password": "fjelltopp",
         "activity_streams_email_notifications": false,
         "state": "active",
-        "fullname": "Fjelltopp Admin"
-      },
-      {
-        "email": "fjelltopp_editor@fjelltopp.org",
-        "about": null,
-        "display_name": "Fjelltopp Editor",
-        "name": "fjelltopp_editor",
-        "password": "fjelltopp",
-        "activity_streams_email_notifications": false,
-        "state": "active",
-        "fullname": "Fjelltopp Editor"
-      },
-      {
-        "email": "fjelltopp_member@fjelltopp.org",
-        "about": null,
-        "display_name": "Fjelltopp Member",
-        "name": "fjelltopp_member",
-        "password": "fjelltopp",
-        "activity_streams_email_notifications": false,
-        "state": "active",
-        "fullname": "Fjelltopp Member"
-      },
-      {
-        "email": "test_admin@test.org",
-        "about": null,
-        "display_name": "Test Admin",
-        "name": "test_admin",
-        "password": "fjelltopp",
-        "activity_streams_email_notifications": false,
-        "state": "active",
-        "fullname": "Test Admin"
-      },
-      {
-        "email": "test_editor@test.org",
-        "about": null,
-        "display_name": "Test Editor",
-        "name": "test_editor",
-        "password": "fjelltopp",
-        "activity_streams_email_notifications": false,
-        "state": "active",
-        "fullname": "Test Editor"
-      },
-      {
-        "email": "test_member@test.org",
-        "about": null,
-        "display_name": "Test Member",
-        "name": "test_member",
-        "password": "fjelltopp",
-        "activity_streams_email_notifications": false,
-        "state": "active",
-        "fullname": "Test Member"
+        "fullname": "Dr Chas Nelson"
       }
     ]
   }
+  


### PR DESCRIPTION
## Description

Improves the demo data to include all the TRG institutes and one admin per institute.

Also adds images to the groups for visualising on the home page.

relates (but is not dependent on) fjelltopp/ckanext-zarr#44

## Dependencies

Submodules will need updating before merging (but after their respective PRs are merged)

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [x] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
