### PR TITLE
fix: update dsl.groovy to support submodules for infrastructure

### DIFF
--- a/jenkins/dsl.groovy
+++ b/jenkins/dsl.groovy
@@ -91,6 +91,7 @@ pipelineJob("CKAN-deploy") {
           extensions {
             submoduleOptions {
               parentCredentials(true)
+              recursiveSubmodules(true)
             }
           }
           scriptPath('jenkinsfiles/zarr_deploy.groovy')


### PR DESCRIPTION
## Description

Copies over the fix for recursive submodules - just in case we ever need to reinitialise Jenkins for Zarr (i.e. after handover).

relates fjelltopp/fjelltopp-infrastructure#319
relates fjelltopp/ckan_project_template#3

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
